### PR TITLE
Fix missing lookahead restriction

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -29024,7 +29024,7 @@
           `export` ExportFromClause FromClause `;`
           `export` NamedExports `;`
           `export` VariableStatement[~Yield, +Await]
-          `export` [lookahead != `using`] Declaration[~Yield, +Await]
+          `export` [lookahead &notin; { `using`, `await` }] Declaration[~Yield, +Await]
           `export` `default` HoistableDeclaration[~Yield, +Await, +Default]
           `export` `default` ClassDeclaration[~Yield, +Await, +Default]
           `export` `default` [lookahead &notin; { `function`, `async` [no LineTerminator here] `function`, `class` }] AssignmentExpression[+In, ~Yield, +Await] `;`


### PR DESCRIPTION
This is the companion PR to https://github.com/tc39/proposal-explicit-resource-management/pull/222 and updates https://github.com/tc39/ecma262/pull/3000.