### PR TITLE
Change early error for modifiers

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -35921,7 +35921,7 @@ THH:mm:ss.sss
         <emu-grammar>Atom :: `(?` RegularExpressionModifiers `-` RegularExpressionModifiers `:` Disjunction `)`</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if the source text matched by the first |RegularExpressionModifiers| and the source text matched by the second |RegularExpressionModifiers| are both empty.
+            It is a Syntax Error if the source text matched by the second |RegularExpressionModifiers| is empty.
           </li>
           <li>
             It is a Syntax Error if the source text matched by the first |RegularExpressionModifiers| contains the same code point more than once.


### PR DESCRIPTION
```grammarkdown
Atom :: `(?` RegularExpressionModifiers `-` RegularExpressionModifiers `:` Disjunction `)`
```

Currently we issue an error if *both* the first and second modifier sets are empty (e.g., `(?-:)`), but does not error when only the second modifier set is empty (e.g., `(?im-:)`). As suggested by @JLHwung, this changes the rule to only error when the second modifier set is missing, which would cover both of these cases.