### PR TITLE
Add missing 'constructor' definitions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -47024,6 +47024,10 @@ THH:mm:ss.sss
           1. Return _value_.
         </emu-alg>
       </emu-clause>
+      <emu-clause id="sec-disposablestack.prototype.constructor">
+        <h1>DisposableStack.prototype.constructor</h1>
+        <p>The initial value of `DisposableStack.prototype.constructor` is %DisposableStack%.</p>
+      </emu-clause>
 
       <emu-clause id="sec-disposablestack.prototype.defer">
         <h1>DisposableStack.prototype.defer ( _onDispose_ )</h1>
@@ -47216,6 +47220,11 @@ THH:mm:ss.sss
           1. Perform ? AddDisposableResource(_asyncDisposableStack_.[[DisposeCapability]], *undefined*, ~async-dispose~, _F_).
           1. Return _value_.
         </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-asyncdisposablestack.prototype.constructor">
+        <h1>AsyncDisposableStack.prototype.constructor</h1>
+        <p>The initial value of `AsyncDisposableStack.prototype.constructor` is %AsyncDisposableStack%.</p>
       </emu-clause>
 
       <emu-clause id="sec-asyncdisposablestack.prototype.defer">


### PR DESCRIPTION
Adds missing entries for `DisposableStack.prototype.constructor` and `AsyncDisposableStack.prototype.constructor`.

/cc @waldemarhorwat, @syg

Fixes https://github.com/tc39/proposal-explicit-resource-management/issues/249