### PR TITLE
Disallow using/await using in a switch case/default clause

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -21729,7 +21729,10 @@
             It is a Syntax Error if the BoundNames of |BindingList| contains any duplicate entries.
           </li>
           <li>
-            It is a Syntax Error if the goal symbol is |Script| and |UsingDeclaration| is not contained, either directly or indirectly, within a |Block|, |CaseBlock|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, or |ClassStaticBlockBody|.
+            It is a Syntax Error if the goal symbol is |Script| and |UsingDeclaration| is not contained, either directly or indirectly, within a |Block|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, or |ClassStaticBlockBody|.
+          </li>
+          <li>
+            It is a Syntax Error if |UsingDeclaration| is contained directly within the |StatementList| of either a |CaseClause| or |DefaultClause|.
           </li>
         </ul>
         <emu-grammar>
@@ -21745,7 +21748,10 @@
             It is a Syntax Error if the BoundNames of |BindingList| contains any duplicate entries.
           </li>
           <li>
-            It is a Syntax Error if the goal symbol is |Script| and |AwaitUsingDeclaration| is not contained, either directly or indirectly, within a |Block|, |CaseBlock|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, or |ClassStaticBlockBody|.
+            It is a Syntax Error if the goal symbol is |Script| and |AwaitUsingDeclaration| is not contained, either directly or indirectly, within a |Block|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, or |ClassStaticBlockBody|.
+          </li>
+          <li>
+            It is a Syntax Error if |AwaitUsingDeclaration| is contained directly within the |StatementList| of either a |CaseClause| or |DefaultClause|.
           </li>
         </ul>
         <emu-grammar>LexicalBinding : BindingIdentifier Initializer?</emu-grammar>
@@ -25946,7 +25952,7 @@
         <p>A potential tail position call that is immediately followed by return GetValue of the call result is also a possible tail position call. A function call cannot return a Reference Record, so such a GetValue operation will always return the same value as the actual function call result.</p>
       </emu-note>
       <emu-note>
-        <p>A `using` declaration or `await using` declaration that precedes a call in the same |Block|, |CaseBlock|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, or |ClassStaticBlockBody| prevents that call from being a possible tail position call.</p>
+        <p>A `using` declaration or `await using` declaration that precedes a call in the same |Block|, |ForStatement|, |ForInOfStatement|, |FunctionBody|, |GeneratorBody|, |AsyncGeneratorBody|, |AsyncFunctionBody|, or |ClassStaticBlockBody| prevents that call from being a possible tail position call.</p>
       </emu-note>
 
       <emu-grammar>StatementList : StatementList StatementListItem</emu-grammar>
@@ -26042,13 +26048,10 @@
       <emu-grammar>CaseBlock : `{` CaseClauses? DefaultClause CaseClauses? `}`</emu-grammar>
       <emu-alg>
         1. Let _has_ be *false*.
-        1. If the first |CaseClauses| is present, then
-          1. Set _has_ to HasCallInTailPosition of the first |CaseClauses| with argument _call_.
-          1. If _has_ is *true*, return *true*.
-          1. If HasUnterminatedUsingDeclaration of the first |CaseClauses| is *true*, return *false*.
+        1. If the first |CaseClauses| is present, then, set _has_ to HasCallInTailPosition of the first |CaseClauses| with argument _call_.
+        1. If _has_ is *true*, return *true*.
         1. Set _has_ to HasCallInTailPosition of |DefaultClause| with argument _call_.
         1. If _has_ is *true*, return *true*.
-        1. If HasUnterminatedUsingDeclaration of |DefaultClause| is *true*, return *false*.
         1. If the second |CaseClauses| is present, set _has_ to HasCallInTailPosition of the second |CaseClauses| with argument _call_.
         1. Return _has_.
       </emu-alg>
@@ -26056,7 +26059,6 @@
       <emu-alg>
         1. Let _has_ be HasCallInTailPosition of |CaseClauses| with argument _call_.
         1. If _has_ is *true*, return *true*.
-        1. If HasUnterminatedUsingDeclaration of |CaseClauses| is *true*, return *false*.
         1. Return HasCallInTailPosition of |CaseClause| with argument _call_.
       </emu-alg>
       <emu-grammar>
@@ -26292,9 +26294,6 @@
         StatementListItem :
           Statement
 
-        CaseBlock :
-          `{` `}`
-
         Declaration :
           HoistableDeclaration
           ClassDeclaration
@@ -26315,24 +26314,6 @@
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
-      </emu-alg>
-
-      <emu-grammar>CaseClauses : CaseClauses CaseClause</emu-grammar>
-      <emu-alg>
-        1. Let _has_ be HasUnterminatedUsingDeclaration of |CaseClauses|.
-        1. If _has_ is *true*, return *true*.
-        1. Return HasUnterminatedUsingDeclaration of |CaseClause|.
-      </emu-alg>
-
-      <emu-grammar>
-        CaseClause :
-          `case` Expression `:` StatementList?
-
-        DefaultClause :
-          `default` `:` StatementList?
-      </emu-grammar>
-      <emu-alg>
-        1. If |StatementList| is present, return HasUnterminatedUsingDeclaration of |StatementList|.
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -47005,6 +47005,7 @@ THH:mm:ss.sss
           1. Return _value_.
         </emu-alg>
       </emu-clause>
+
       <emu-clause id="sec-disposablestack.prototype.constructor">
         <h1>DisposableStack.prototype.constructor</h1>
         <p>The initial value of `DisposableStack.prototype.constructor` is %DisposableStack%.</p>


### PR DESCRIPTION
As requested by implementers, this disallows `using`/`await using` directly nested within a `case` or `default` clause. This also removes some of the logic in `HasCallInTailPosition` and `HasUnterminatedUsingDeclaration` that pertain to `case` and `default` as `HasUnterminatedUsingDeclaration` would no longer apply.

Fixes https://github.com/tc39/proposal-explicit-resource-management/issues/215

/cc @syg, @iainireland, @waldemarhorwat