### PR TITLE
Remove excess argument to 'return' method

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -49692,7 +49692,7 @@ THH:mm:ss.sss
           1. If _return_ is *undefined*, then
             1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, « *undefined* »).
           1. Else,
-            1. Let _result_ be Completion(Call(_return_, _obj_, « *undefined* »)).
+            1. Let _result_ be Completion(Call(_return_, _obj_, « »)).
             1. IfAbruptRejectPromise(_result_, _promiseCapability_).
             1. Let _resultWrapper_ be Completion(PromiseResolve(%Promise%, _result_)).
             1. IfAbruptRejectPromise(_resultWrapper_, _promiseCapability_).


### PR DESCRIPTION
This removes an unnecessary `undefined` argument to the iterator return method in [%AsyncIteratorPrototype% [ %Symbol.asyncDispose% ] ( )](https://tc39.es/ecma262/pr/3000/#sec-%asynciteratorprototype%-%symbol.asyncdispose%).

Fixes https://github.com/tc39/proposal-explicit-resource-management/issues/273